### PR TITLE
Hackathon 404 + 2018 sponsor logos

### DIFF
--- a/_includes/main_nav.html
+++ b/_includes/main_nav.html
@@ -3,7 +3,6 @@
     <li><a href="{{site.baseurl}}/about">About</a></li>
     <li><a href="{{site.baseurl}}/showcase">Showcase</a></li>
     <li><a href="{{site.baseurl}}/calendar">Events</a></li>
-    <!--<li><a href="https://hackathon.uqcs.org.au">Hackathon</a></li>-->
     <li><a href="{{site.baseurl}}/contact">Contact</a></li>
     <li><a href="https://join.uqcs.org.au">Join!</a></li>
 </ul>

--- a/_includes/main_nav.html
+++ b/_includes/main_nav.html
@@ -3,7 +3,7 @@
     <li><a href="{{site.baseurl}}/about">About</a></li>
     <li><a href="{{site.baseurl}}/showcase">Showcase</a></li>
     <li><a href="{{site.baseurl}}/calendar">Events</a></li>
-    <li><a href="https://hackathon.uqcs.org.au">Hackathon</a></li>
+    <!--<li><a href="https://hackathon.uqcs.org.au">Hackathon</a></li>-->
     <li><a href="{{site.baseurl}}/contact">Contact</a></li>
     <li><a href="https://join.uqcs.org.au">Join!</a></li>
 </ul>

--- a/_includes/side_nav.html
+++ b/_includes/side_nav.html
@@ -5,7 +5,7 @@
 <li><a href="/showcase">Showcase</a></li>
 <li class="divider"></li>
 <li><a href="/calendar">Events</a></li>
-<li><a href="/hackathon/index">Hackathon</a></li>
+<!--<li><a href="/hackathon/index">Hackathon</a></li>-->
 <li class="divider"></li>
 <li><a href="/contact">Contact</a></li>
 <li class="divider"></li>

--- a/_includes/side_nav.html
+++ b/_includes/side_nav.html
@@ -5,7 +5,6 @@
 <li><a href="/showcase">Showcase</a></li>
 <li class="divider"></li>
 <li><a href="/calendar">Events</a></li>
-<!--<li><a href="/hackathon/index">Hackathon</a></li>-->
 <li class="divider"></li>
 <li><a href="/contact">Contact</a></li>
 <li class="divider"></li>


### PR DESCRIPTION
Fixes #111. Have set the sidebar nav hackathon link to https://hackathon.uqcs.org/ and fixed the missing divider. Also addresses #110, though merging #115 over the top will be best.