### PR TITLE
Better event layout for smaller screens.

### DIFF
--- a/content/events/_index.html
+++ b/content/events/_index.html
@@ -36,6 +36,7 @@ draft: false
 
 }
 
+/* stack buttons and center for small mobile devices. */
 @media screen and (max-width: 374px) {
     .fc-header-toolbar {
         justify-content: center;
@@ -43,6 +44,36 @@ draft: false
 
     .fc-header-toolbar > .fc-left {
         text-align: center;
+    }
+}
+
+/* collapse table entries to multiple rows at sizes below tablet. */
+@media screen and (max-width: 767px) {
+    .fc-list-item {
+        display: grid;
+        grid-template-columns: 1.5rem 1fr;
+    }
+
+    .fc-list-item-time {
+        grid-column: 2;
+        grid-row: 1;
+        width: unset;
+    }
+
+    .fc-list-item-marker {
+        grid-column: 1;
+        grid-row: 1;
+        width: unset;
+    }
+
+    td.fc-list-item-title {
+        grid-column: 1 / span 2;
+        grid-row: 2;
+        border: none;
+        padding-top: 0;
+
+        box-sizing: border-box;
+        width: 100%;
     }
 }
 </style>
@@ -65,6 +96,7 @@ draft: false
                 buttonText: 'list'
             }
         },
+        height: 'auto',
         googleCalendarApiKey: 'AIzaSyC-c78Fu_Rw36zKXh9XvCpTOXvlNPXlyNc',
         eventSources: [
             { googleCalendarId: 'q3n3pce86072n9knt3pt65fhio@group.calendar.google.com' },
@@ -81,6 +113,12 @@ draft: false
                 click: function() {
                     window.open('https://calendar.google.com/calendar/embed?src=q3n3pce86072n9knt3pt65fhio%40group.calendar.google.com&ctz=Australia%2FBrisbane');
                 }
+            }
+        },
+        eventClick: function(info) {
+            info.jsEvent.preventDefault(); // don't let the browser navigate
+            if (info.event.url) {
+                window.open(info.event.url); // open in new tab
             }
         },
     });


### PR DESCRIPTION
The event list layout is currently really cramped on mobile. This rearranges the elements to better suit a vertical experience, for those smaller screens. Makes use of CSS breakpoints and CSS grid.

Month view is unchanged and remains practically unusable on small screens.

# New
## Mobile Medium
![image](https://user-images.githubusercontent.com/39479354/78868272-f5b8f600-7a85-11ea-89d8-8a38914453f0.png)

## Mobile Small
![image](https://user-images.githubusercontent.com/39479354/78868292-fbaed700-7a85-11ea-98df-c4680a6e6ebb.png)

# Old 
## Mobile Small
![image](https://user-images.githubusercontent.com/39479354/78868324-0e291080-7a86-11ea-97f8-5574dde7ed12.png)
