### PR TITLE
Talks Page

### DIFF
--- a/content/talks/_index.html
+++ b/content/talks/_index.html
@@ -1,6 +1,6 @@
 ---
 title: "Talks"
-date: 2020-10-22T22:26:10+11:00
+date: 2020-10-20T22:26:10+11:00
 draft: false
 ---
 <section class="section">

--- a/content/talks/_index.html
+++ b/content/talks/_index.html
@@ -6,7 +6,7 @@ draft: false
 <section class="section">
     <div class="container is-size-5">
         <div class="columns is-centered">
-            <div class="column is-12">
+            <div class="column is-12 is-8-desktop">
                 <div class="block has-text-centered">
                     <h1 class="title is-2">UQCS Tech Talks 2020</h1>
                 </div>

--- a/content/talks/_index.html
+++ b/content/talks/_index.html
@@ -1,0 +1,23 @@
+---
+title: "Talks"
+date: 2020-10-22T22:26:10+11:00
+draft: false
+---
+<section class="section">
+    <div class="container is-size-5">
+        <div class="columns is-centered">
+            <div class="column is-12">
+                <div class="block has-text-centered">
+                    <h1 class="title is-2">UQCS Tech Talks 2020</h1>
+                </div>
+                {{< youtube id="videoseries?list=PLjGNXiulWlOTBK9pP8HIDiGSij9Eeh1_Y" >}}
+                <br/>
+
+                <div class="block has-text-centered">
+                    <h1 class="title is-2">UQCS Tech Talks 2019</h1>
+                </div>
+                {{< youtube id="videoseries?list=PLjGNXiulWlOQR1dvAJ8Si8eeZ38_zJ8dm" >}}
+            </div>
+        </div>
+    </div>
+</section>

--- a/layouts/partials/nav/navbar-end.html
+++ b/layouts/partials/nav/navbar-end.html
@@ -3,9 +3,9 @@
 <a class="navbar-item" href="{{ .Site.BaseURL }}/about">
     About
 </a>
-<!--<a class="navbar-item" href="{{ .Site.BaseURL }}/showcase">-->
-<!--    Showcase-->
-<!--</a>-->
+<a class="navbar-item" href="{{ .Site.BaseURL }}/talks">
+    Talks
+</a>
 <a class="navbar-item" href="{{ .Site.BaseURL }}/showcase">
     Showcase
 </a>


### PR DESCRIPTION
Placeholder talks page until Paul finishes his grid. Just embeds the 2020 and 2019 playlists in the page.

<img width="1320" alt="Screen Shot 2020-10-22 at 5 37 05 pm" src="https://user-images.githubusercontent.com/9084563/96840055-4e356b00-148d-11eb-9dc7-386f6b5ff8fa.png">
