### PR TITLE
Add Better HTML Title Attributes

### DIFF
--- a/content/competitions/_index.html
+++ b/content/competitions/_index.html
@@ -1,5 +1,5 @@
 ---
-title: "competitions"
+title: "Competitions"
 date: 2020-02-23T12:44:31+11:00
 draft: false
 ---

--- a/content/competitions/codejam-2020.html
+++ b/content/competitions/codejam-2020.html
@@ -1,5 +1,5 @@
 ---
-title: "codejam"
+title: "CodeJam"
 date: 2020-03-22T12:16:23+10:00
 draft: false
 ---

--- a/content/competitions/hackathon-2020.html
+++ b/content/competitions/hackathon-2020.html
@@ -1,5 +1,5 @@
 ---
-title: "hackathon"
+title: "Hackathon"
 date: 2020-09-28T00:43:00+10:00
 draft: false
 ---

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -4,7 +4,7 @@
 <meta name="description" content="{{ with .Site.Params.description }}{{ . }}{{ end }}">
 <meta name="author" content="{{ with .Site.Params.name }}{{ . }}{{ end }}">
 
-<title>{{ .Site.Title }}</title>
+<title>{{ block "title" . }}{{ .Site.Title }} {{ with .Params.Title }} | {{ . }}{{ end }}{{ end }}</title>
 
 {{ "<!-- Compiled and minified CSS -->" | safeHTML }}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -22,7 +22,6 @@
 <link rel="shortcut icon" type="image/x-icon" href="{{ .Site.Params.custom_ico }}">
 <link rel="icon" media="(prefers-color-scheme:dark)" href="/img/favicon/favicon-dark.ico" type="image/png" id="dark-scheme-icon"/>
 <link rel="icon" media="(prefers-color-scheme:light)" href="/img/favicon/favicon-light.ico" type="image/png" id="light-scheme-icon"/>
-
 <!-- Load webcomponents and script to convert external MD files to HTML -->
 {{ if .Params.mdconvert}}
 <script src="https://cdn.jsdelivr.net/npm/@webcomponents/webcomponentsjs@2/webcomponents-loader.min.js"></script>


### PR DESCRIPTION
Fixes #174. Also updates capitalisation of page names so we don't look foolish.

HTML titles will now appear like this, with the page name in the header: 
<img width="218" alt="Screen Shot 2020-11-01 at 10 07 51 am" src="https://user-images.githubusercontent.com/9084563/97792441-1c10cf80-1c2a-11eb-9ba3-579e00f67ac0.png">

Should improve SEO a tad.
