### PR TITLE
Add talks 2021 playlist to talks page

### DIFF
--- a/content/talks/_index.html
+++ b/content/talks/_index.html
@@ -8,6 +8,12 @@ draft: false
         <div class="columns is-centered">
             <div class="column is-12 is-8-desktop">
                 <div class="block has-text-centered">
+                    <h1 class="title is-2">UQCS Tech Talks 2021</h1>
+                </div>
+                {{< youtube id="videoseries?list=PLjGNXiulWlOSG8nF5GiVPBrBhR_gvrdMw" >}}
+                <br/>
+
+                <div class="block has-text-centered">
                     <h1 class="title is-2">UQCS Tech Talks 2020</h1>
                 </div>
                 {{< youtube id="videoseries?list=PLjGNXiulWlOTBK9pP8HIDiGSij9Eeh1_Y" >}}


### PR DESCRIPTION
As per title, adds current year's playlist to the talks page in the same style as the others.