### PR TITLE
Slack to Discord migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ The UQCS site is a place to show off both the club itself, and the work its memb
 You can contribute code by forking the repository, making your changes and creating a pull request. It's encouraged to create an issue for the changes you plan on making in your pull request and you should mention the IDs of any issues you work on in your pull request description.
 
 Want help with creating a pull request? No problem!
-Email us at contact@uqcs.org.au for help, or ask in [Slack](https://slack.uqcs.org.au/).
+Email us at contact@uqcs.org.au for help, or ask in [Discord](https://discord.uqcs.org/).
 
 Please note we have a code of conduct, please follow it in all your interactions with the project.
 
@@ -18,7 +18,7 @@ Please note we have a code of conduct, please follow it in all your interactions
 5. [Request a review](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review) from one of the reviewers listed in the reviewers section of this document.
 6. When your pull request is reviewed and approved, click `Squash and Merge`, clear the commits from below the merge title, then confirm.
 
-If the steps above are unclear, jump onto [Slack](https://slack.uqcs.org.au/) and ask in #projects for advice.
+If the steps above are unclear, jump onto [Discord](https://discord.uqcs.org/) and ask in #projects for advice.
 
 ## Reviewers
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You can contribute code by forking the repository, making your changes and creat
 For more information checkout the [CONTRIBUTING.md](CONTRIBUTING.md)
 
 Want help with creating a pull request? No problem!
-Email us at contact@uqcs.org.au for help, or ask in [Slack](https://slack.uqcs.org.au/).
+Email us at contact@uqcs.org.au for help, or ask in [Discord](https://discord.uqcs.org/).
 
 
 ### Getting Setup

--- a/content/community/_index.html
+++ b/content/community/_index.html
@@ -13,8 +13,8 @@ draft: false
                 In the past, we've run Games, Jackbox, Trivia and Movie Nights, BBQs, study sessions, end-of-semester
                 drinks, and workshops; we also frequently collaborate with other tech and related interests societies,
                 both in and out of UQ.</p>
-            <p>We have an extremely active Discord community consisting of thousands of members, comprised of current 
-                students, alumni, and other people in the Brisbane tech community.</p>
+            <p>We have an extremely active <a href="https://discord.uqcs.org/">Discord community</a> consisting of thousands
+                of members, comprised of current students, alumni, and other people in the Brisbane tech community.</p>
             <p>By providing mentors, advertisement, and helping with infrastructure, we support workshops held by 
                 <a href="https://djangogirls.org/">Django Girls</a> (a group photo of 
                 which is pictured below!).</p>

--- a/content/community/_index.html
+++ b/content/community/_index.html
@@ -24,9 +24,10 @@ draft: false
 
             <h3> How can I get involved?</h3>
             <p>The best way to get involved is attending our twice-weekly events and sticking around after the presentation
-                to talk to other members and indulge in some free pizza. Joining our Discord server, finding channels 
-                you’re interested in, asking questions and sharing your opinions is another great way of getting to 
-                know the rest of UQCS’ members and enhancing your university experience.</p>
+                to talk to other members and indulge in some free pizza. Joining our 
+                <a href="https://discord.uqcs.org/">Discord server</a>, finding channels you’re interested in, asking 
+                questions and sharing your opinions is another great way of getting to know the rest of UQCS’ members and 
+                enhancing your university experience.</p>
             <p>UQCS is made up of a management committee of around a dozen people, composed of the President, Secretary
                 and Treasurer, and the remaining members being part of the general committee. The management committee
                 is elected towards the end of each year at the Annual General Meeting (AGM). </p>

--- a/content/community/_index.html
+++ b/content/community/_index.html
@@ -13,7 +13,7 @@ draft: false
                 In the past, we've run Games, Jackbox, Trivia and Movie Nights, BBQs, study sessions, end-of-semester
                 drinks, and workshops; we also frequently collaborate with other tech and related interests societies,
                 both in and out of UQ.</p>
-            <p>We have an extremely active <a href="https://discord.uqcs.org/">Discord community</a> consisting of thousands
+            <p>We have an extremely active <a href="https://discord.uqcs.org/">Discord community</a> consisting of hundreds
                 of members, comprised of current students, alumni, and other people in the Brisbane tech community.</p>
             <p>By providing mentors, advertisement, and helping with infrastructure, we support workshops held by 
                 <a href="https://djangogirls.org/">Django Girls</a> (a group photo of 

--- a/content/community/_index.html
+++ b/content/community/_index.html
@@ -13,7 +13,7 @@ draft: false
                 In the past, we've run Games, Jackbox, Trivia and Movie Nights, BBQs, study sessions, end-of-semester
                 drinks, and workshops; we also frequently collaborate with other tech and related interests societies,
                 both in and out of UQ.</p>
-            <p>We have an extremely active Slack community consisting of thousands of members, comprised of current 
+            <p>We have an extremely active Discord community consisting of thousands of members, comprised of current 
                 students, alumni, and other people in the Brisbane tech community.</p>
             <p>By providing mentors, advertisement, and helping with infrastructure, we support workshops held by 
                 <a href="https://djangogirls.org/">Django Girls</a> (a group photo of 
@@ -24,7 +24,7 @@ draft: false
 
             <h3> How can I get involved?</h3>
             <p>The best way to get involved is attending our twice-weekly events and sticking around after the presentation
-                to talk to other members and indulge in some free pizza. Joining our Slack workspace, finding channels 
+                to talk to other members and indulge in some free pizza. Joining our Discord server, finding channels 
                 you’re interested in, asking questions and sharing your opinions is another great way of getting to 
                 know the rest of UQCS’ members and enhancing your university experience.</p>
             <p>UQCS is made up of a management committee of around a dozen people, composed of the President, Secretary

--- a/content/community/_index.html
+++ b/content/community/_index.html
@@ -13,8 +13,8 @@ draft: false
                 In the past, we've run Games, Jackbox, Trivia and Movie Nights, BBQs, study sessions, end-of-semester
                 drinks, and workshops; we also frequently collaborate with other tech and related interests societies,
                 both in and out of UQ.</p>
-            <p>We have an extremely active <a href="https://discord.uqcs.org/">Discord community</a> consisting of hundreds
-                of members, comprised of current students, alumni, and other people in the Brisbane tech community.</p>
+            <p>We have an extremely active <a href="https://discord.uqcs.org/">Discord community</a> comprised of current 
+                students, alumni, and other people in the Brisbane tech community.</p>
             <p>By providing mentors, advertisement, and helping with infrastructure, we support workshops held by 
                 <a href="https://djangogirls.org/">Django Girls</a> (a group photo of 
                 which is pictured below!).</p>

--- a/content/connect/_index.html
+++ b/content/connect/_index.html
@@ -35,7 +35,7 @@ draft: false
                                 <p class="heading">Engage</p>
                                 <p class="title">Facebook</p>
                                 <span class="icon has-text-dark">
-                                    <i class="fab fa-3x fa-facebook-square"></i>
+                                    <i class="fab fa-3x fa-facebook"></i>
                                 </span>
                             </a>
                         </div>
@@ -46,7 +46,7 @@ draft: false
                                 <p class="heading">Develop</p>
                                 <p class="title">Projects</p>
                                 <span class="icon has-text-dark">
-                                    <i class="fab fa-3x fa-github-square"></i>
+                                    <i class="fab fa-3x fa-github"></i>
                                 </span>
                             </a>
                         </div>

--- a/content/connect/_index.html
+++ b/content/connect/_index.html
@@ -42,7 +42,7 @@ draft: false
                     </div>
                     <div class="level-item has-text-centered">
                         <div>
-                            <a href="https://github.com/UQComputingSociety/">
+                            <a href="https://github.com/UQComputingSociety">
                                 <p class="heading">Develop</p>
                                 <p class="title">Projects</p>
                                 <span class="icon has-text-dark">

--- a/content/connect/_index.html
+++ b/content/connect/_index.html
@@ -11,7 +11,7 @@ draft: false
             <div class="content">
                 <p>
                     UQCS prides itself on promoting and facilitating a community of students
-                    engaged with software and technology. Join us on our community slack to
+                    engaged with software and technology. Join us on our community Discord to
                     chat about university, your latest side project or newest hobby! Follow
                     the society Facebook page to stay up to date on the latest events and
                     announcements. Finally, work on your skills by contributing to our open
@@ -20,11 +20,11 @@ draft: false
                 <nav class="level">
                     <div class="level-item has-text-centered">
                         <div>
-                            <a href="https://slack.uqcs.org.au">
+                            <a href="https://discord.uqcs.org/">
                                 <p class="heading">Chat</p>
-                                <p class="title">Slack</p>
+                                <p class="title">Discord</p>
                                 <span class="icon has-text-dark">
-                                    <i class="fab fa-3x fa-slack"></i>
+                                    <i class="fab fa-3x fa-discord"></i>
                                 </span>
                             </a>
                         </div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -6,7 +6,7 @@
                 <div class="level-item">
                     <div><div class="is-size-4 has-text-white">Come, chat with us!</div>
                     We would love to have you join our 
-                    <a href="https://slack.uqcs.org.au/">Slack community</a>!
+                    <a href="https://discord.uqcs.org/">Discord community</a>!
                 </div>
                 </div>
             </div>

--- a/layouts/partials/nav/navbar-start.html
+++ b/layouts/partials/nav/navbar-start.html
@@ -5,7 +5,7 @@
     </span>
 </a>
 
-<a class="navbar-item is-hidden-touch" href="https://github.com/UQComputingSociety/">
+<a class="navbar-item is-hidden-touch" href="https://github.com/UQComputingSociety">
     <span class="icon is-medium">
         <i height=20 class="fab fa-github fa-fw fa-lg"></i>
     </span>

--- a/layouts/partials/nav/navbar-start.html
+++ b/layouts/partials/nav/navbar-start.html
@@ -1,19 +1,19 @@
 {{ "<!-- Navbar Start -->" | safeHTML }}
 <a class="navbar-item is-hidden-touch" href="https://www.facebook.com/uqcomputing">
     <span class="icon is-medium">
-        <i height=20 class="fab fa-facebook-square fa-fw fa-lg"></i>
+        <i height=20 class="fab fa-facebook fa-fw fa-lg"></i>
     </span>
 </a>
 
 <a class="navbar-item is-hidden-touch" href="https://github.com/UQComputingSociety/">
     <span class="icon is-medium">
-        <i height=20 class="fab fa-github-square fa-fw fa-lg"></i>
+        <i height=20 class="fab fa-github fa-fw fa-lg"></i>
     </span>
 </a>
 
 <a class="navbar-item is-hidden-touch" href="http://twitter.com/UQComputing">
     <span class="icon is-medium">
-        <i height=20 class="fab fa-twitter-square fa-fw fa-lg"></i>
+        <i height=20 class="fab fa-twitter fa-fw fa-lg"></i>
     </span>
 </a>
 

--- a/layouts/partials/nav/navbar-start.html
+++ b/layouts/partials/nav/navbar-start.html
@@ -17,9 +17,9 @@
     </span>
 </a>
 
-<a class="navbar-item is-hidden-touch" href="https://slack.uqcs.org.au">
+<a class="navbar-item is-hidden-touch" href="https://discord.uqcs.org/">
     <span class="icon is-medium">
-        <i height=20 class="fab fa-slack fa-fw fa-lg"></i>
+        <i height=20 class="fab fa-discord fa-fw fa-lg"></i>
     </span>
 </a>
 

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -3,17 +3,17 @@
 <div class="buttons" id="share-buttons">
     <a class="button is-dark" href="https://www.facebook.com/uqcomputing">
         <span class="icon">
-            <i height="20" width="20" class="fab fa-lg fa-facebook-square"></i>
+            <i height="20" width="20" class="fab fa-lg fa-facebook"></i>
         </span>
     </a>
     <a class="button is-dark" href="https://github.com/UQComputingSociety/">
         <span class="icon">
-            <i height="20" width="20" class="fab fa-lg fa-github-square"></i>
+            <i height="20" width="20" class="fab fa-lg fa-github"></i>
         </span>
     </a>
     <a class="button is-dark" href="http://twitter.com/UQComputing">
         <span class="icon">
-            <i height="20" width="20" class="fab fa-lg fa-twitter-square"></i>
+            <i height="20" width="20" class="fab fa-lg fa-twitter"></i>
         </span>
     </a>
     <a class="button is-dark" href="https://discord.uqcs.org/">

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -16,9 +16,9 @@
             <i height="20" width="20" class="fab fa-lg fa-twitter-square"></i>
         </span>
     </a>
-    <a class="button is-dark" href="https://slack.uqcs.org.au">
+    <a class="button is-dark" href="https://discord.uqcs.org/">
         <span class="icon">
-            <i height="20" width="20" class="fab fa-lg fa-slack"></i>
+            <i height="20" width="20" class="fab fa-lg fa-discord"></i>
         </span>
     </a>
     <a class="button is-dark" href="https://www.linkedin.com/company/uqcs">

--- a/layouts/partials/share.html
+++ b/layouts/partials/share.html
@@ -6,7 +6,7 @@
             <i height="20" width="20" class="fab fa-lg fa-facebook"></i>
         </span>
     </a>
-    <a class="button is-dark" href="https://github.com/UQComputingSociety/">
+    <a class="button is-dark" href="https://github.com/UQComputingSociety">
         <span class="icon">
             <i height="20" width="20" class="fab fa-lg fa-github"></i>
         </span>


### PR DESCRIPTION
Since UQCS has migrated from Slack to Discord, this pull request updates any Slack references on the website to now point to Discord.

Note: historical references on the CodeJam event pages have been left as is.

Also hyperlinked the previous plain text on the Community page, as it seemed to make sense.

Updates build and look fine locally, except the nav/footer social icon seems a little mis-aligned, since most other icons are square where the Discord icon is a little taller. Thinking about what to do there but welcome comments.