### PR TITLE
Update uqcs.org.au links to uqcs.org

### DIFF
--- a/content/connect/_index.html
+++ b/content/connect/_index.html
@@ -77,8 +77,8 @@ draft: false
                     </div>
                     <div class="level-item has-text-centered">
                         <div>
-                            <a class="" href="https://sponsor.uqcs.org.au/">
-                                <p class="heading">sponsor.uqcs.org.au</p>
+                            <a class="" href="https://sponsor.uqcs.org/">
+                                <p class="heading">sponsor.uqcs.org</p>
                                 <p class="title">Sponsor</p>
                                 <span class="icon has-text-dark">
                                     <i class="fas fa-3x fa-heart"></i>

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -16,7 +16,7 @@
 		    UQCS is a student society, run by students, for students. We engage with a broad range of student interests, from digital design to software engineering. We're an inclusive club focused on developing the next generation of innovators, through twice-weekly events spanning educational, social, and industry emphases. Our membership spans undergraduates, postgraduates, recent graduates, and alumni.
 	</p>
         <div class="buttons is-centered" >
-            <a href="https://join.uqcs.org.au">
+            <a href="https://join.uqcs.org/">
                 <button class="button join-button is-large has-text-weight-bold">
                     Join UQCS!
                 </button>

--- a/layouts/partials/nav/navbar-end.html
+++ b/layouts/partials/nav/navbar-end.html
@@ -21,7 +21,7 @@
 
 <div class="navbar-item">
     <div class="buttons">
-        <a class="button join-button" href="https://join.uqcs.org.au/">
+        <a class="button join-button" href="https://join.uqcs.org/">
             <strong>Join!</strong>
         </a>
     </div>


### PR DESCRIPTION
Update the few external links to join.uqcs.org.au and sponsor.uqcs.org.au to their uqcs.org equivalents, as the org.au redirects anyway.

Emails are untouched since that has not been migrated yet.