### PR TITLE
fixed sponsor banner bug for mobile

### DIFF
--- a/layouts/partials/sponsor-banner.html
+++ b/layouts/partials/sponsor-banner.html
@@ -7,7 +7,7 @@
             </div>
 
             <!-- object tag enables links inside the SVG image -->
-            <object type="image/svg+xml" data="{{ "/img/sponsors/all_sponsors.svg" | relURL }}">
+            <object class="sponsor-img" type="image/svg+xml" data="{{ "/img/sponsors/all_sponsors.svg" | relURL }}">
                 Sponsor Banner
             </object>
         </div>


### PR DESCRIPTION
The sponsor banner wasn't adjusting for size of mobile phones. You had to zoom out to see the sponsors and the rest of the website wasn't responding well to that zoom out. Soz didn't create an issue, this was just bothering me

