### PR TITLE
A link to the UQCS merch store was notably missing. This rectifies that

### DIFF
--- a/layouts/partials/nav/navbar-end.html
+++ b/layouts/partials/nav/navbar-end.html
@@ -15,6 +15,9 @@
 <a class="navbar-item" href="{{ "/connect/" | relURL }}">
     Connect
 </a>
+<a class="navbar-item" href="https://store.uqcs.org/" target="_blank">
+    Store
+</a>
 <a class="navbar-item" href="{{ "/lambda/" | relURL }}">
     Why Lambda?
 </a>


### PR DESCRIPTION
Now people will know where to shop for that new look