### PR TITLE
Update "Connect" page to remove `.au` from email addresses

### DIFF
--- a/content/connect/_index.html
+++ b/content/connect/_index.html
@@ -66,8 +66,8 @@ draft: false
                 <nav class="level">
                     <div class="level-item has-text-centered">
                         <div>
-                            <a href="mailto:contact@uqcs.org.au">
-                                <p class="heading">contact@uqcs.org.au</p>
+                            <a href="mailto:contact@uqcs.org">
+                                <p class="heading">contact@uqcs.org</p>
                                 <p class="title">Email</p>
                                 <span class="icon has-text-dark">
                                     <i class="fas fa-3x fa-envelope-open-text"></i>


### PR DESCRIPTION
Jimmothy has finally done the thing, see: https://discord.com/channels/813324385179271168/905101643027214347/1011613788560175175

<img width="444" alt="Screen Shot 2022-08-24 at 10 15 51 pm" src="https://user-images.githubusercontent.com/9084563/186525106-4e12348f-cf04-4790-81ef-4f771995a0d9.png">

### Change Summary
- Remove the now unnecessary `.au` suffix from the contact email: `contact@uqcs.org.au` `->` `contact@uqcs.org`.