### PR TITLE
Change footer year to 2022

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
             </div>
         </div>
         <div class="has-text-centered">
-            &copy; UQ Computing Society 2021
+            &copy; UQ Computing Society 2022
         </div>
     </div>
 </footer>


### PR DESCRIPTION
Given that we still have 2 and a half months to go, we should bring UQCS into the modern age.