### PR TITLE
Update lambda page to also mention COMP3400

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,7 +4,7 @@ on:
     branches: [ '*' ]
 jobs:
   check-build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - name: Setup Hugo

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -4,7 +4,7 @@ on:
     branches: [ '*' ]
 jobs:
   check-build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - name: Setup Hugo

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
 

--- a/content/lambda/_index.html
+++ b/content/lambda/_index.html
@@ -17,7 +17,7 @@ draft: false
 		</p>
 		<p>
 
-			While Turing’s more approachable abstraction would go on to become the dominant influence in the development of what we think of today as “imperative” programming languages (C, COBOL, Fortran), many of the concepts introduced by Lambda Calculus live on in modern programming languages. This impact is most evident in functional languages like Haskell and Clojure, but a resurgence in the popularity of functional programming has led to more prevalent, object-oriented languages like Python and Java “borrowing” functional concepts like anonymous functions as well as operations like map, reduce, and filter. This critical influence is why students will still learn Lambda Calculus in courses like UQ’s Theory of Computing (COMP2048) and why UQCS is proud to use Church’s lambda to represent our society.
+			While Turing’s more approachable abstraction would go on to become the dominant influence in the development of what we think of today as “imperative” programming languages (C, COBOL, Fortran), many of the concepts introduced by Lambda Calculus live on in modern programming languages. This impact is most evident in functional languages like Haskell and Clojure, but a resurgence in the popularity of functional programming has led to more prevalent, object-oriented languages like Python and Java “borrowing” functional concepts like anonymous functions as well as operations like map, reduce, and filter. This critical influence is why students will still learn Lambda Calculus in courses like UQ’s Theory of Computing (COMP2048) and Functional & Logic Programming (COMP3400), and why UQCS is proud to use Church’s lambda to represent our society.
                 </p>
             </div>
         </div>


### PR DESCRIPTION
Also updates our GitHub actions to run on `ubuntu-latest`, as `ubuntu-18.04` will soon be fully deprecated (https://github.com/actions/runner-images/issues/6002).