### PR TITLE
Update actions for new Pages deployment method

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,16 +1,21 @@
 name: Check Build On PR
+
 on:
   pull_request:
     branches: [ '*' ]
+    
 jobs:
   check-build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.64.0'
+          hugo-version: '0.120.4'
           extended: true
+
       - name: Build
         run: hugo --minify

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,29 +1,51 @@
-name: github pages
+name: Deploy to GitHub Pages
 
 on:
   push:
     branches:
-      - master
+      - main
+
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout
+        uses: actions/checkout@v4
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2
         with:
-          hugo-version: '0.64.0'
+          hugo-version: '0.121.0'
           extended: true
 
       - name: Build
         run: hugo --minify
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-          publish_dir: ./public
-          user_name: uqcs
-          user_email: contact@uqcs.org.au
+          path: ./public
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-22.04
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
I was meaning to do this a while ago, but it fell off my radar.

This PR updates the actions deployment method to the newer [actions based deployment for GitHub Pages](https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/). Additionally, I've added the `workflow_dispatch` trigger for manual redeploys, swapped over to using the `GITHUB_TOKEN` and updated versions of actions and Hugo.

Merging this PR will require changing Pages settings and default branch to `main` inline with our other repos.