### PR TITLE
Showcase: Fixed link for HPHelper

### DIFF
--- a/content/showcase/_index.html
+++ b/content/showcase/_index.html
@@ -480,9 +480,9 @@ draft: false
                     {{< showcase-item
                         src="/img/media/showcase/HPCover.jpg"
                         title="HPHelper"
-                        caption="A suite of tools for running Paranoia: High Programmers. Currently with  a scenario and character generator, future features include user  submitted content and a live version for extra Fun! Other RPGs are un-fun. Play Paranoia: High Programmers. <br /> <a href='https://github.com/lsenjov/hphelper'>Source Code</a>"
+                        caption="A suite of tools for running Paranoia: High Programmers. Currently with  a scenario and character generator, future features include user  submitted content and a live version for extra Fun! Other RPGs are un-fun. Play Paranoia: High Programmers."
                         image-class="showcase-image"
-                        link="http://45.55.87.246/hphelper/"
+                        link="https://github.com/lsenjov/hphelper"
                         class="showcase-element has-text-centered"
                     >}}
                     {{< showcase-item


### PR DESCRIPTION
A quick fix to change the link to HPHelper within the showcase. Got approval from lsenjov.