### PR TITLE
Restructuring Sponsorship Information

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -28,7 +28,7 @@
                             <li class="footer-link"><a href="https://discord.uqcs.org">Discord</a></li>
                             <li class="footer-link"><a href="https://github.com/uqcomputingsociety/design">Design
                                     Kit</a></li>
-                            <li class="footer-link"><a href="https://sponsor.uqcs.org">Sponsorship</a></li>
+                            <li class="footer-link"><a href="https://sponsor.uqcs.org">Sponsorship Packages</a></li>
                         </ul>
                     </div>
                 </div>

--- a/layouts/partials/nav/navbar-end.html
+++ b/layouts/partials/nav/navbar-end.html
@@ -12,6 +12,9 @@
 <a class="navbar-item" href="{{ "/events/" | relURL }}">
     Events
 </a>
+<a class="navbar-item" href="https://sponsor.uqcs.org/">
+    Sponsorship
+</a>
 <a class="navbar-item" href="{{ "/connect/" | relURL }}">
     Connect
 </a>


### PR DESCRIPTION
UQCS Committee has requested some changes to the structure of sponsorship information on the website. These are slight adjustments, hopefully getting the ball rolling. The sponsorship nav-bar item should probably link to a brand new page listing our sponsors and providing some more details.